### PR TITLE
qcom/sepolicy: Remove duplicate definition

### DIFF
--- a/common/file.te
+++ b/common/file.te
@@ -129,9 +129,6 @@ type mmi_data_file, file_type, data_file_type;
 #bluetooth firmware file types
 type bt_firmware_file, fs_type, contextmount_type;
 
-#needed by vold
-type  proc_dirty_ratio, fs_type;
-
 #File types by mmi
 type mmi_socket, file_type;
 


### PR DESCRIPTION
https://github.com/CyanogenMod/android_external_sepolicy/blob/cm-13.0/file.te#L197

Change-Id: I3e7628c8e99e7267db3efe22d4a427639fb7304d